### PR TITLE
Remove predefined byte array length

### DIFF
--- a/ESP8266_DJI_DroneID_Throwie.ino
+++ b/ESP8266_DJI_DroneID_Throwie.ino
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 // bytes derrived from: https://github.com/DJISDKUser/metasploit-framework/blob/62e36f1b5c6cae0abed9c86c769bd1656931061c/modules/auxiliary/dos/wifi/droneid.rb#L187
-byte wifipkt[128] = {
+byte wifipkt[] = {
     0x80,                      // type/subtype
     0x00,                      // flags
     0x00, 0x00,                // duration


### PR DESCRIPTION
With the `128` removed:

![image](https://user-images.githubusercontent.com/5891284/159789849-57f202fb-509f-4d2b-928b-1b8d29cdf011.png)

Original source code:

![image](https://user-images.githubusercontent.com/5891284/159789936-49dad237-33f4-47d1-b67c-6ff6941416d2.png)
